### PR TITLE
Change setup.py to prevent premature imports of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 pillow
-Cython  # Needed for installation only

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,19 @@
-
-
 import sys
 
-import numpy as np
-import setuptools
-
+import distutils.sysconfig
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
-from Cython.Distutils import build_ext
 
 # Cython extension.
-source_files = ['jpeg_ls/_CharLS.pyx',
-                'jpeg_ls/CharLS_src/interface.cpp',
-                'jpeg_ls/CharLS_src/jpegls.cpp',
-                'jpeg_ls/CharLS_src/header.cpp']
+source_files = [
+    "jpeg_ls/_CharLS.pyx",
+    "jpeg_ls/CharLS_src/interface.cpp",
+    "jpeg_ls/CharLS_src/jpegls.cpp",
+    "jpeg_ls/CharLS_src/header.cpp",
+]
 
-include_dirs = ['jpeg_ls/CharLS_src',
-                setuptools.distutils.sysconfig.get_python_inc(),
-                np.get_include()]
+include_dirs = ["jpeg_ls/CharLS_src", distutils.sysconfig.get_python_inc()]
 
 # Platform-specific arguments
 if sys.platform == "win32":
@@ -35,25 +30,51 @@ else:
 # extra_compile_args = ['-m64'] #, '-nostdlib', '-lgcc']
 # extra_link_args = ['-m64'] #, '-nostdlib', '-lgcc']
 
-ext = Extension('_CharLS', source_files,
-                language='c++',
-                include_dirs=include_dirs,
-                extra_compile_args=extra_compile_args,
-                extra_link_args=extra_link_args)
+
+# https://luminousmen.com/post/resolve-cython-and-numpy-dependencies
+# https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy
+def create_build_ext(*args, **kwargs):
+    # Delay imports until setup requirements can be processed
+    # from setuptools.command.build_ext import build_ext
+    from Cython.Distutils import build_ext
+
+    class cython_numpy_build_ext(build_ext):
+        def finalize_options(self):
+            super().finalize_options()
+            # Prevent numpy from thinking it is still in its setup process:
+            __builtins__.__NUMPY_SETUP__ = False
+            import numpy as np
+
+            self.include_dirs.append(np.get_include())
+
+    return cython_numpy_build_ext(*args, **kwargs)
+
 
 # Do it.
-version = '1.0.3'
+version = "1.0.3"
 
-setup(name='CharPyLS',
-      packages=find_packages(),
-      package_data={'': ['*.txt', '*.cpp', '*.h', '*.pyx']},
-      cmdclass={'build_ext': build_ext},
-      ext_modules=[ext],
+setup(
+    name="CharPyLS",
+    packages=find_packages(),
+    package_data={"": ["*.txt", "*.cpp", "*.h", "*.pyx"]},
+    cmdclass={"build_ext": create_build_ext},
+    ext_modules=[
+        Extension(
+            "_CharLS",
+            source_files,
+            language="c++",
+            include_dirs=include_dirs,
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
+        )
+    ],
+    setup_requires=["setuptools>=18.0", "cython", "numpy"],
 
-      # Metadata
-      version=version,
-      license='MIT',
-      author='Pierre V. Villeneuve',
-      author_email='pierre.villeneuve@gmail.com',
-      description='JPEG-LS for Python via CharLS C++ Library',
-      url='https://github.com/Who8MyLunch/CharPyLS')
+    # Metadata
+    version=version,
+    license="MIT",
+    author="Pierre V. Villeneuve",
+    author_email="pierre.villeneuve@gmail.com",
+    description="JPEG-LS for Python via CharLS C++ Library",
+    url="https://github.com/Who8MyLunch/CharPyLS",
+)


### PR DESCRIPTION
Previous version of setup.py assumed that numpy and Cython were already
installed when setup.py was first called. If they were not, the install
would fail even if these packages were listed as dependencies. This
approach incapsulates the imports so that they are not run before the
requirements can be met.